### PR TITLE
fix: 修复react/crud性别字段没值时默认显示第一个选项的问题

### DIFF
--- a/react/demo/01-basic/08-crud.html
+++ b/react/demo/01-basic/08-crud.html
@@ -61,7 +61,7 @@
       state = {
         name: '',
         age: '',
-        gender: '',
+        gender: '保密',
         phone: ''
       };
 
@@ -103,6 +103,7 @@
             <div>
               <span>性别: </span>
               <select value={gender} onChange={e=>this.handleChange(e, 'gender')}>
+                <option value="保密">保密</option>
                 <option value="男">男</option>
                 <option value="女">女</option>
               </select>


### PR DESCRIPTION
state = {
        name: '',
        age: '',
        gender: '',
        phone: ''
      };

gender为“”时，select显示为第一个选项